### PR TITLE
thumbnail fix

### DIFF
--- a/src/server/views/includes/pubProjects.pug
+++ b/src/server/views/includes/pubProjects.pug
@@ -3,11 +3,12 @@
   ul#projects-slider.cS-hidden
     each eg in projects
       if eg.thumbnail
+        - var img = Array.isArray(eg.thumbnail) ? eg.thumbnail[0] : eg.thumbnail
         .element-item.col-xs-12.col-sm-4.col-md-3.col-lg-2
            a(class="wrapper-link", href= env.EDITOR_ADDRESS + '/#present:Username='+eg.owner+'&ProjectName='+eg.projectName + '&editMode=true', target='_blank')
             .h-thumbnail
               .img-container
-                img.img-responsive.lazy.center-block.img-thumbnail(src='images/placeholder.jpg', data-src= eg.thumbnail, style='width: 100%;')
+                img.img-responsive.lazy.center-block.img-thumbnail(src=img, data-src=img, style='width: 100%;')
                 .overlay
                   .caption.text-center= eg.notes || 'No description provided.'
               ul.list-group


### PR DESCRIPTION
Fixes the issue of broken project thumbnails. Apparently some `.thumbnail` fields are strings (probably older projects) and some are an array of strings. Grabbing the first item if it's an array almost solves the problem, but still some show the placeholder image instead. Fixed this by setting the thumbnail to the same value for both `src` and `data-src` (for some reason, both were needed).